### PR TITLE
ユーザ登録ページのビュー調整（フッター追加）

### DIFF
--- a/app/assets/stylesheets/application.scss
+++ b/app/assets/stylesheets/application.scss
@@ -33,6 +33,7 @@ body {
 
 h2, #new_user.new_user {
   text-align: center;
+  margin-top: 15px;
 }
 
 ul{
@@ -103,6 +104,26 @@ ul{
 .field_def {
   margin-top: 20px;
   margin-bottom: 30px;
+}
+
+.bottom{
+  margin-top: 15px;
+  &  a {
+    display: block;;
+    margin: 0 auto;
+  }
+}
+
+.bottom a{
+  display: block;;
+  margin: 0 auto;
+}
+
+.footer_usr{
+  height: 300px;
+  width: 100%;
+  display: block;
+  margin: 0 auto;
 }
 
 a {

--- a/app/views/devise/registrations/new.html.haml
+++ b/app/views/devise/registrations/new.html.haml
@@ -1,7 +1,8 @@
+
 #header
-  #{image_tag 'logo.png'}
+  =link_to image_tag(src="logo.png"),root_path
 %h2 新規会員登録
-= link_to "ログアウト", destroy_user_session_path, method: :delete
+-# = link_to "ログアウト", destroy_user_session_path, method: :delete
 
 .contents
   = form_for(resource, as: resource_name, url: registration_path(resource_name)) do |f|
@@ -102,4 +103,8 @@
     .actions
       = f.submit "Next"
 
--# = render "devise/shared/links"
+.bottom
+  = render "devise/shared/links"
+  = link_to "ログアウト", destroy_user_session_path, method: :delete
+
+=render 'layouts/footer_usr'

--- a/app/views/devise/sessions/new.html.haml
+++ b/app/views/devise/sessions/new.html.haml
@@ -1,5 +1,5 @@
 #header
-  　#{image_tag 'logo.png'}
+  =link_to image_tag(src="logo.png"),root_path
 %h2 Log in
 
 .contents
@@ -18,4 +18,7 @@
         = f.label :remember_me
     .actions
       = f.submit "Log in"
-  -# = render "devise/shared/links"
+
+.bottom
+  = render "devise/shared/links"
+  = link_to "ログアウト", destroy_user_session_path, method: :delete

--- a/app/views/devise/shared/_links.html.haml
+++ b/app/views/devise/shared/_links.html.haml
@@ -1,11 +1,11 @@
 - if controller_name != 'sessions'
-  = link_to "Log in", new_session_path(resource_name)
+  = link_to "ログイン", new_session_path(resource_name)
   %br/
 - if devise_mapping.registerable? && controller_name != 'registrations'
-  = link_to "Sign up", new_registration_path(resource_name)
-  %br/
+  = link_to "アカウント登録", new_registration_path(resource_name)
+  -# %br/
 - if devise_mapping.recoverable? && controller_name != 'passwords' && controller_name != 'registrations'
-  = link_to "Forgot your password?", new_password_path(resource_name)
+  = link_to "パスワードを忘れた方はこちら", new_password_path(resource_name)
   %br/
 - if devise_mapping.confirmable? && controller_name != 'confirmations'
   = link_to "Didn't receive confirmation instructions?", new_confirmation_path(resource_name)

--- a/app/views/layouts/_footer_usr.html.haml
+++ b/app/views/layouts/_footer_usr.html.haml
@@ -2,7 +2,7 @@
   %ul.footer__contents
     %li.footer__contents__content
       %h2.footer__contents__content__head
-        FURIMAについて
+        -# FURIMAについて
       %ul
         %li
           =link_to"会社概要","#"
@@ -14,7 +14,7 @@
           =link_to"ポイントに関する特約","#"
     %li.footer__contents__content
       %h2.footer__contents__content__head
-        FURIMAをみる
+        -# FURIMAをみる
       %ul
         %li
           =link_to"カテゴリー一覧","#"
@@ -22,7 +22,7 @@
           =link_to"ブランド一覧","#"
     %li.footer__contents__content
       %h2.footer__contents__content__head
-        ヘルプ&ガイド
+        -# ヘルプ&ガイド
       %ul
         %li
           =link_to"FURIMAガイド","#"
@@ -33,13 +33,4 @@
   .footer__logo
     %a
       = image_tag src="logo-white.png",size:"160x46.34"
-    -# %p
-    -#   FURIMA
-%a
-  .purchasesBtn
-    %span.purchasesBtn__text
-      出品する
-    %span.purchasesBtn__icon
-      %a
-        = image_tag src="icon_camera.png",size:"54x54"
 

--- a/app/views/layouts/application.html.haml
+++ b/app/views/layouts/application.html.haml
@@ -2,6 +2,7 @@
 %html
   %head
     %meta{content: "text/html; charset=UTF-8", "http-equiv": "Content-Type"}/
+    %meta{content: "width=device-width, initial-scale=1.0", name: "viewport"}/
     %title FreemarketSample70h
     %script{src: "https://js.pay.jp/", type: "text/javascript"}
     = csrf_meta_tags

--- a/config/initializers/carrierwave.rb
+++ b/config/initializers/carrierwave.rb
@@ -15,6 +15,7 @@ CarrierWave.configure do |config|
       region: 'exitap-northeast-1'
     }
     config.fog_directory  = 'teamh70ki'
-    config.asset_host = 'https://s3-ap-northeast-1.amazonaws.com/teamh70ki'
+    config.asset_host = 'https://s3-ap-northeast-1.amazonaws.com/teamh70ki' #カリキュラム
+    # config.asset_host = 'https://teamh70ki.s3.amazonaws.com' #投稿した画像が表示されないとき
   end
 end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,6 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-
 ActiveRecord::Schema.define(version: 2020_03_10_114534) do
 
   create_table "addresses", options: "ENGINE=InnoDB DEFAULT CHARSET=utf8", force: :cascade do |t|


### PR DESCRIPTION
### What
ユーザー新規登録のフッターをTOPのトンマナに合わせる。
ログイン画面に新規登録やPw忘れのリンクを戻す。
_footer_usrをlayoutsに追加

### why
本番デプロイに向けたビュー 統一。