### PR TITLE
商品購入機能実装(サーバーサイド)

### DIFF
--- a/app/assets/stylesheets/application.scss
+++ b/app/assets/stylesheets/application.scss
@@ -3,7 +3,7 @@
 @import "items.index";
 @import "font-awesome-sprockets";
 @import "font-awesome";
-@import "index";
+
 body {
   margin: 0 auto;
 }

--- a/app/assets/stylesheets/purchases.scss
+++ b/app/assets/stylesheets/purchases.scss
@@ -1,0 +1,3 @@
+// Place all the styles related to the purchases controller here.
+// They will automatically be included in application.css.
+// You can use Sass (SCSS) here: http://sass-lang.com/

--- a/app/controllers/purchases_controller.rb
+++ b/app/controllers/purchases_controller.rb
@@ -1,0 +1,40 @@
+class PurchasesController < ApplicationController
+  require 'payjp'#Payjpの読み込み
+  before_action :set_card, :set_item
+
+  def index
+    if @card.blank?
+      #登録された情報がない場合にカード登録画面に移動
+      redirect_to controller: "cards", action: "new"
+    else
+      Payjp.api_key = ENV['PAYJP_PRIVATE_KEY']
+      #保管した顧客IDでpayjpから情報取得
+      customer = Payjp::Customer.retrieve(@card.customer_id) 
+      #カード情報表示のためインスタンス変数に代入
+      @default_card_information = customer.cards.retrieve(@card.card_id)
+    end
+  end
+
+  def pay
+    Payjp.api_key = ENV['PAYJP_PRIVATE_KEY']
+    Payjp::Charge.create(
+      :amount => @item.price, #支払金額を引っ張ってくる
+      :customer => @card.customer_id,  #顧客ID
+      :currency => 'jpy',              #日本円
+    )
+    @item.update(buyer_id: current_user.id) #itemsテーブルのbuyer_idに購入者のIDを入れる
+    redirect_to action: 'done' #完了画面に移動
+  end
+
+  def done
+  end
+
+  private
+  def set_card
+    @card = Card.find_by(user_id: current_user.id)
+  end
+
+  def set_item
+    @item = Item.find(params[:item_id])
+  end 
+end

--- a/app/controllers/purchases_controller.rb
+++ b/app/controllers/purchases_controller.rb
@@ -5,7 +5,7 @@ class PurchasesController < ApplicationController
   def index
     if @card.blank?
       #登録された情報がない場合にカード登録画面に移動
-      redirect_to controller: "cards", action: "new"
+      redirect_to new_card_path
     else
       Payjp.api_key = ENV['PAYJP_PRIVATE_KEY']
       #保管した顧客IDでpayjpから情報取得
@@ -23,7 +23,7 @@ class PurchasesController < ApplicationController
       :currency => 'jpy',              #日本円
     )
     @item.update(buyer_id: current_user.id) #itemsテーブルのbuyer_idに購入者のIDを入れる
-    redirect_to action: 'done' #完了画面に移動
+    redirect_to done_item_purchases_path #完了画面に移動
   end
 
   def done

--- a/app/helpers/purchases_helper.rb
+++ b/app/helpers/purchases_helper.rb
@@ -1,0 +1,2 @@
+module PurchasesHelper
+end

--- a/app/views/purchases/done.html.haml
+++ b/app/views/purchases/done.html.haml
@@ -1,0 +1,27 @@
+%h1.buy-content__attention
+  %i.far.fa-clock
+    発送をお待ちください
+  %h2.buy-content__attention__title
+    購入が完了しました
+  .buy-content__item
+    .buy-content__item__inner
+      .buy-item-main
+        .buy-item-image
+          -# = image_tag "#{@item.images[0].url}", size: '64x64', class: 'buydetails-contet__image'
+        .buy-item-detail
+          .buy-item-name
+            = @item.name
+            %p.buy-price
+              %span 
+                = "¥#{@item.price.to_s}"
+              %span
+                .shipping-free (税込) 送料込み
+  .buy-content__item
+    %form.buy-form
+      .buy-price-table
+        .buy-price-table__left
+          支払金額
+        .buy-price-table__right
+          = "¥#{@item.price.to_s}"
+      .buy-content__user-info__submit
+        = link_to "トップページへ戻る", root_path, class: 'buy-content__user-info__submit__button'

--- a/app/views/purchases/done.html.haml
+++ b/app/views/purchases/done.html.haml
@@ -7,7 +7,7 @@
     .buy-content__item__inner
       .buy-item-main
         .buy-item-image
-          -# = image_tag "#{@item.images[0].url}", size: '64x64', class: 'buydetails-contet__image'
+          -# = image_tag "#{@item.images[0].url}", size: '64x64', class: 'buydetails-contet__image'image 投稿機能が未実装のため、実装完了までコメントアウト
         .buy-item-detail
           .buy-item-name
             = @item.name

--- a/app/views/purchases/index.html.haml
+++ b/app/views/purchases/index.html.haml
@@ -1,0 +1,48 @@
+%h2.buy-content__title
+  購入内容の確認
+  .buy-content__item
+    .buy-content__item__inner
+      .buy-item-main
+        .buy-item-image
+          -# = image_tag "#{@item.images[0].url}", size: '64x64', class: 'buydetails-contet__image'
+        .buy-item-detail
+          .buy-item-name
+            = @item.name
+            %p.buy-price
+              = "¥#{@item.price.to_s}"
+              %span.shipping-free (税込) 送料込み
+  .buy-content__item
+    %form.buy-form
+      .buy-price-table
+        .buy-price-table__left
+          支払金額
+        .buy-price-table__right
+          = "¥#{@item.price.to_s}"
+  .buy-content__user-info
+    .buy-content__user-info__inner
+      %h3 支払方法
+      .user-info-update
+        = link_to "変更する", "#", calss:"update-btn"
+      .user-info-text
+      - if @default_card_information.blank?
+        %br /
+      - else
+        = "**** **** **** " + "#{@default_card_information.last4}"
+        %br
+        - exp_month = @default_card_information.exp_month.to_s
+        - exp_year = @default_card_information.exp_year.to_s.slice(2,3)
+        = "有効期限 " + exp_month + " / " + exp_year
+        %br
+  .buy-content__user-info
+    .buy-content__user-info__inner              
+      %h3 配送先
+      .user-info-update
+        = link_to "変更する","#", calss:"update-btn"
+      .user-info-text
+        〒111-1111
+        %br
+        大阪府大阪市北区〇〇1-11
+        %br
+        山田太郎
+        = form_tag(action: :pay, method: :post) do
+          %button.buy-button{type:"submit"} 購入する

--- a/app/views/purchases/index.html.haml
+++ b/app/views/purchases/index.html.haml
@@ -4,7 +4,7 @@
     .buy-content__item__inner
       .buy-item-main
         .buy-item-image
-          -# = image_tag "#{@item.images[0].url}", size: '64x64', class: 'buydetails-contet__image'
+          -# = image_tag "#{@item.images[0].url}", size: '64x64', class: 'buydetails-contet__image' image投稿機能が未実装のため、実装完了までコメントアウト
         .buy-item-detail
           .buy-item-name
             = @item.name

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -1,4 +1,6 @@
 Rails.application.routes.draw do
+  get 'purchases/index'
+  get 'purchases/done'
   devise_for :users, controllers: {
     registrations: 'users/registrations',
   }
@@ -10,7 +12,16 @@ Rails.application.routes.draw do
 
   root to: 'items#index'
 
-  resources :items, only: [:index,:show,:new]
+  resources :items, only: [:index,:show,:new] do
+    resources :purchases, only: [:index] do
+      collection do
+        get 'index', to: 'purchases#index'
+        post 'pay', to: 'purchases#pay'
+        get 'done', to: 'purchases#done'
+      end
+    end
+  end  
+
   resources :cards, only: [:new, :show] do
     collection do
       post 'show', to: 'cards#show'

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -1,6 +1,5 @@
 Rails.application.routes.draw do
-  get 'purchases/index'
-  get 'purchases/done'
+  
   devise_for :users, controllers: {
     registrations: 'users/registrations',
   }
@@ -15,7 +14,6 @@ Rails.application.routes.draw do
   resources :items, only: [:index,:show,:new] do
     resources :purchases, only: [:index] do
       collection do
-        get 'index', to: 'purchases#index'
         post 'pay', to: 'purchases#pay'
         get 'done', to: 'purchases#done'
       end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,9 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-
 ActiveRecord::Schema.define(version: 2020_03_11_075653) do
-
 
   create_table "addresses", options: "ENGINE=InnoDB DEFAULT CHARSET=utf8", force: :cascade do |t|
     t.integer "zip", null: false
@@ -58,6 +56,7 @@ ActiveRecord::Schema.define(version: 2020_03_11_075653) do
 
   create_table "images", options: "ENGINE=InnoDB DEFAULT CHARSET=utf8", force: :cascade do |t|
     t.string "image", null: false
+    t.integer "item_id", null: false
     t.datetime "created_at", null: false
     t.datetime "updated_at", null: false
   end
@@ -70,6 +69,11 @@ ActiveRecord::Schema.define(version: 2020_03_11_075653) do
     t.string "region", null: false
     t.string "condition", null: false
     t.string "shipping", null: false
+    t.integer "size_id"
+    t.integer "category_id", null: false
+    t.integer "user_id", null: false
+    t.integer "buyer_id"
+    t.integer "brand_id"
     t.datetime "created_at", null: false
     t.datetime "updated_at", null: false
   end
@@ -95,6 +99,7 @@ ActiveRecord::Schema.define(version: 2020_03_11_075653) do
     t.datetime "created_at", null: false
     t.datetime "updated_at", null: false
     t.string "nickname", null: false
+    t.string "image"
     t.string "first_name", null: false
     t.string "last_name", null: false
     t.string "first_name_kana", null: false
@@ -103,7 +108,6 @@ ActiveRecord::Schema.define(version: 2020_03_11_075653) do
     t.string "year_birth_at", null: false
     t.string "month_birth_at", null: false
     t.string "day_birth_at", null: false
-    t.string "image"
     t.index ["email"], name: "index_users_on_email", unique: true
     t.index ["reset_password_token"], name: "index_users_on_reset_password_token", unique: true
   end

--- a/spec/controllers/purchases_controller_spec.rb
+++ b/spec/controllers/purchases_controller_spec.rb
@@ -1,0 +1,19 @@
+require 'rails_helper'
+
+RSpec.describe PurchasesController, type: :controller do
+
+  describe "GET #index" do
+    it "returns http success" do
+      get :index
+      expect(response).to have_http_status(:success)
+    end
+  end
+
+  describe "GET #done" do
+    it "returns http success" do
+      get :done
+      expect(response).to have_http_status(:success)
+    end
+  end
+
+end

--- a/spec/helpers/purchases_helper_spec.rb
+++ b/spec/helpers/purchases_helper_spec.rb
@@ -1,0 +1,15 @@
+require 'rails_helper'
+
+# Specs in this file have access to a helper object that includes
+# the PurchasesHelper. For example:
+#
+# describe PurchasesHelper do
+#   describe "string concat" do
+#     it "concats two strings with spaces" do
+#       expect(helper.concat_strings("this","that")).to eq("this that")
+#     end
+#   end
+# end
+RSpec.describe PurchasesHelper, type: :helper do
+  pending "add some examples to (or delete) #{__FILE__}"
+end

--- a/spec/views/purchases/done.html.haml_spec.rb
+++ b/spec/views/purchases/done.html.haml_spec.rb
@@ -1,0 +1,5 @@
+require 'rails_helper'
+
+RSpec.describe "purchases/done.html.haml", type: :view do
+  pending "add some examples to (or delete) #{__FILE__}"
+end

--- a/spec/views/purchases/index.html.haml_spec.rb
+++ b/spec/views/purchases/index.html.haml_spec.rb
@@ -1,0 +1,5 @@
+require 'rails_helper'
+
+RSpec.describe "purchases/index.html.haml", type: :view do
+  pending "add some examples to (or delete) #{__FILE__}"
+end


### PR DESCRIPTION
# what
- 登録済みのクレジットカードでの商品購入
- 未登録で購入へリンクした場合カード登録へ遷移
- 購入完了後は完了ページからトップページへ遷移
- 購入された商品のbuyer_idカラムにcurrent_user(購入者)のidを入れることで区別
# why
- フリマアプリ必須機能のため
- セキュリティの観点からpayjpを使用

カード登録機能に関してはタスクを切り分け昨日LGTM済です。
別担当のためimageの呼び出し部コメントアウトしてます。
空のscssファイルはこの後のマークアップで使用します。